### PR TITLE
Add standalone to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A Jupyter extension for compiling and displaying images described by the [TikZ](
 ## Requirements
 
 - IPython/Jupyter
-- LaTeX (`xelatex`)
+- LaTeX (`xelatex`) 
+	- package `standalone`
 - ImageMagick
 
 ## Installation


### PR DESCRIPTION
I had a clean installation of xelatex and It took me few hours to figure out, that pdf file is not generated because I don't have package `standalone`.