### PR TITLE
Allow to use core.diplay.Image directly on image

### DIFF
--- a/tikzmagic/tikzmagic.py
+++ b/tikzmagic/tikzmagic.py
@@ -87,7 +87,7 @@ def latex2image(latex, density, export_file=None):
          # convert PDF to PNG
         sh_convert(in_file=temp_pdf, out_file=temp_png, density=density)
 
-        return Image(data=b64encode(open(temp_png, "rb").read()))
+        return Image(temp_png)
     finally:
         # remove temp directory
         shutil.rmtree(temp_dir)


### PR DESCRIPTION
Without this modification, tikzmagic tried to display a broken image. This repair works for me on 
jupyter 4.4.0